### PR TITLE
Fix optional chaining in lambda token retrieval

### DIFF
--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -48,7 +48,7 @@ export default function ({
       context: Context,
       callback: APIGatewayProxyCallback,
     ) {
-      const token = (tokenHeaderName && event.headers[tokenHeaderName]) || undefined;
+      const token = tokenHeaderName ? event.headers?.[tokenHeaderName] : undefined;
       const method = event.httpMethod.toLowerCase();
       const path = event.path;
 


### PR DESCRIPTION
## Summary
- use optional chaining for retrieving the token from Lambda event headers