### PR TITLE
Fix async expectations in deno tests

### DIFF
--- a/tests/deno.test.ts
+++ b/tests/deno.test.ts
@@ -7,12 +7,12 @@ async function sendCommand(conn: string, args: (string | number)[]) {
 const redis = RedisFromSendCommand('conn', sendCommand);
 
 describe('RedisFromSendCommand', () => {
-  it('hget', () => {
-    expect(redis.hget('foo', 'bar')).resolves.toEqual(['conn', 'HGET', 'foo', 'bar']);
+  it('hget', async () => {
+    await expect(redis.hget('foo', 'bar')).resolves.toEqual(['conn', 'HGET', 'foo', 'bar']);
   });
 
-  it('eval', () => {
-    expect(redis.eval('return KEYS[0] .. ARGV[1]', 1, 'foo', 'bar')).resolves.toEqual([
+  it('eval', async () => {
+    await expect(redis.eval('return KEYS[0] .. ARGV[1]', 1, 'foo', 'bar')).resolves.toEqual([
       'conn',
       'EVAL',
       'return KEYS[0] .. ARGV[1]',


### PR DESCRIPTION
## Summary
- fix missing awaits in `deno.test.ts`